### PR TITLE
Updated to point to build.fhir.org and handle `_code` element

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-fhir-schema
-=======
+# fhir-schema
 
 [![Build Status](https://travis-ci.org/fhir-js/fhir-schema.svg)](https://travis-ci.org/fhir-js/fhir-schema)
 
@@ -7,11 +6,18 @@ fhir-schema
 
 Convert FHIR structure definition into JSON schema.
 
+## Requirements
+
+Make sure you have NodeJS and wget installed.
+
+```
+brew install wget
+```
+
 ## Installation
 
-
 ```sh
-git clone https://github.com/fhir-js/fhir-schema
+git clone https://github.com/niquola/fhir-schema
 cd fhir-schema
 npm install
 npm run setup
@@ -23,11 +29,8 @@ npm run build
 
 ## Layout
 
-
-
-
 ## TODO:
 
-* refactoring
-* support for simple ValueSet
-* support for contained & Bundle validation
+- refactoring
+- support for simple ValueSet
+- support for contained & Bundle validation

--- a/package.json
+++ b/package.json
@@ -2,7 +2,12 @@
     "name": "fhir-schema.js",
     "version": "0.0.1",
     "devDependencies": {
-        "webpack-dev-server": "latest"
+        "tv4": "latest",
+        "ajv": "latest",
+        "js-yaml": "latest",
+        "json-loader": "latest",
+        "js-beautify": "latest",
+        "mocha": "latest"
     },
     "description": "FHIR javascript validation library",
     "repository": {
@@ -10,6 +15,9 @@
         "url": "git@github.com:FHIR/fhir-validation.js.git"
     },
     "scripts": {
+        "test": "node_modules/mocha/bin/mocha --recursive",
+        "setup": "bash scripts/setup.sh",
+        "build": "node scripts/build.js"
     },
     "keywords": [
         "fhir",
@@ -24,19 +32,10 @@
         "url": "https://github.com/FHIR/fhir-validation.js/issues"
     },
     "homepage": "https://github.com/FHIR/fhir-validation.js",
-    "dependencies": { },
-    "devDependencies":{
-        "tv4": "latest",
-        "ajv": "latest",
-        "js-yaml": "latest",
-        "json-loader": "latest",
-        "js-beautify": "latest",
-        "mocha": "latest"
-    },
-    "scripts": {
-        "test": "node_modules/mocha/bin/mocha --recursive",
-        "setup": "bash scripts/setup.sh",
-        "build": "node scripts/build.js"
-    },
-    "files": ["bin", "lib", "src"]
+    "dependencies": {},
+    "files": [
+        "bin",
+        "lib",
+        "src"
+    ]
 }

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,19 +1,22 @@
-sch = require(__dirname + '/../src/generation.js');
-fs = require('fs');
-yaml = require('js-yaml');
+sch = require(__dirname + "/../src/generation.js");
+fs = require("fs");
+yaml = require("js-yaml");
 
 sch.settings.build = true;
 
-var schema = sch.makeSchema(function(s){
-    s.add(require(__dirname + '/../fhir/profiles-resources.json'))
-    s.add(require(__dirname + '/../fhir/profiles-types.json'))
-    return s;
+var schema = sch.makeSchema(function(s) {
+  s.add(require(__dirname + "/../fhir/profiles-resources.json"));
+  //s.add(require(__dirname + '/../fhir/profiles-types.json'))
+  return s;
 });
 
-delete schema.add
+delete schema.add;
 
-if(!fs.existsSync(__dirname + '/../build')){
-  fs.mkdirSync(__dirname + '/../build');
+if (!fs.existsSync(__dirname + "/../build")) {
+  fs.mkdirSync(__dirname + "/../build");
 }
-fs.writeFileSync(__dirname + '/../build/fhir.schema.json', JSON.stringify(schema, null, " "))
-fs.writeFileSync(__dirname + '/../build/fhir.schema.yaml', yaml.dump(schema))
+fs.writeFileSync(
+  __dirname + "/../build/fhir.schema.json",
+  JSON.stringify(schema, null, " ")
+);
+fs.writeFileSync(__dirname + "/../build/fhir.schema.yaml", yaml.dump(schema));

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -6,7 +6,7 @@ sch.settings.build = true;
 
 var schema = sch.makeSchema(function(s) {
   s.add(require(__dirname + "/../fhir/profiles-resources.json"));
-  //s.add(require(__dirname + '/../fhir/profiles-types.json'))
+  s.add(require(__dirname + "/../fhir/profiles-types.json"));
   return s;
 });
 

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,7 +1,7 @@
 set +e
 rm -rf examples/*
 mkdir examples
-wget http://hl7-fhir.github.io/examples-json.zip -O ./examples/my.zip
+wget http://build.fhir.org/examples-json.zip -O ./examples/my.zip
 cd examples
 unzip my.zip
 cd ..
@@ -13,11 +13,11 @@ cd fhir
 rm *.json
 rm *.xml
 
-wget http://hl7-fhir.github.io/all-valuesets.zip
+wget http://build.fhir.org/all-valuesets.zip
 unzip all-valuesets.zip
 
 rm all-valuesets.zip
 rm *.xml
-wget http://hl7-fhir.github.io/search-parameters.json
-wget http://hl7-fhir.github.io/profiles-resources.json
-wget http://hl7-fhir.github.io/profiles-types.json
+wget http://build.fhir.org/search-parameters.json
+wget http://build.fhir.org/profiles-resources.json
+wget http://build.fhir.org/profiles-types.json

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -18,6 +18,6 @@ unzip all-valuesets.zip
 
 rm all-valuesets.zip
 rm *.xml
-wget http://build.fhir.org/search-parameters.json
-wget http://build.fhir.org/profiles-resources.json
-wget http://build.fhir.org/profiles-types.json
+wget https://build.fhir.org/search-parameters.json
+wget https://build.fhir.org/profiles-resources.json
+wget https://build.fhir.org/profiles-types.json

--- a/src/generation.js
+++ b/src/generation.js
@@ -67,12 +67,14 @@ var elementType = function(el) {
     return "object";
   }
   var code = utils.getIn(el, ["type", 0, "code"]);
+  var _code = utils.getIn(el, ["type", 0, "_code"]);
   if (code === "Reference") {
     return buildReferenceSchema(el);
   }
 
   utils.assert(el.type.length == 1, el.path + JSON.stringify(el.type));
-  utils.assert(code, JSON.stringify(el));
+
+  utils.assert(code || _code, JSON.stringify(el));
 
   if (isPrimitive(code)) {
     return code;

--- a/src/generation.js
+++ b/src/generation.js
@@ -1,272 +1,308 @@
-tv4 = require('tv4');
+tv4 = require("tv4");
 
-settings = {validate: {references: false}};
+settings = { validate: { references: false } };
 
 exports.settings = settings;
 exports.typeRef = typeRef;
 exports.element2schema = element2schema;
 exports.makeSchema = makeSchema;
 
-var OVERRIDEN = require('./primitives');
-var utils = require('./utils');
+var OVERRIDEN = require("./primitives");
+var utils = require("./utils");
 
-var isPrimitive = function(tp){
-    return ['string', 'integer', 'number', 'boolean'].indexOf(tp) > -1;
+var isPrimitive = function(tp) {
+  return ["string", "integer", "number", "boolean"].indexOf(tp) > -1;
 };
 
-function typeRef(tp){
-    utils.assert(tp, "expected type");
-    return (settings.refPrefix || '') + '#/definitions/' + (tp == 'id' ? 'fhir_id' : tp);
-};
-
-
-var isRequired = function(el){ return (el.min && el.min === 1) || false; };
-
-var minItems = function(el){ return (el.min && el.min === 0) ? 0 : el.min; };
-
-var isPolymorphic = function(el){ return el.path.indexOf('[x]') > -1;};
-
-var buildReferenceSchema = function(el){
-    var resources = el.type.reduce(function(acc, tp){
-        if(tp.profile){ acc.push(utils.last(tp.profile[0].split('/'))); }
-        return acc;
-    }, []);
-
-    if(!settings.validate.references || resources.length === 0 || resources.indexOf('Resource') > -1){
-        return {$ref: typeRef('Reference')};
-    }
-    var pattern  = '/(#|' + resources.join('|') + ')/i';
-    return { allOf: [
-        {$ref: typeRef('Reference')},
-        {type: 'object', properties: {reference: {type: 'string', pattern: pattern}}}
-    ]};
-};
-
-var elementType = function(el){
-    if(!el.type) {return 'object';}
-    var code = utils.getIn(el, ['type', 0, 'code']);
-    if (code === 'Reference') {
-        return buildReferenceSchema(el);
-    }
-
-    utils.assert(el.type.length == 1, el.path + JSON.stringify(el.type));
-    utils.assert(code, JSON.stringify(el));
-
-    if(isPrimitive(code)) {
-        return code;
-    }
-    if (code === 'BackboneElement') {
-        return 'object';
-    }
-    return {$ref: typeRef(code)};
-};
-
-var expandPath = function(spath, tp){
-    var path = spath.split('.');
-    var last = path[path.length - 1];
-    var newpath = path.slice(0, path.length - 1);
-    newpath.push(last.replace('[x]', utils.capitalize(tp.code)));
-    return newpath.join('.');
+function typeRef(tp) {
+  //utils.assert(tp, "expected type");
+  return (
+    (settings.refPrefix || "") +
+    "#/definitions/" +
+    (tp == "id" ? "fhir_id" : tp)
+  );
 }
 
-var isFhirPrimitive = function(el){
-    var tp = utils.getIn(el, ['type', 0, 'code']);
-    return tp && tp[0].toLowerCase() == tp[0];
+var isRequired = function(el) {
+  return (el.min && el.min === 1) || false;
+};
+
+var minItems = function(el) {
+  return el.min && el.min === 0 ? 0 : el.min;
+};
+
+var isPolymorphic = function(el) {
+  return el.path.indexOf("[x]") > -1;
+};
+
+var buildReferenceSchema = function(el) {
+  var resources = el.type.reduce(function(acc, tp) {
+    if (tp.profile) {
+      acc.push(utils.last(tp.profile[0].split("/")));
+    }
+    return acc;
+  }, []);
+
+  if (
+    !settings.validate.references ||
+    resources.length === 0 ||
+    resources.indexOf("Resource") > -1
+  ) {
+    return { $ref: typeRef("Reference") };
+  }
+  var pattern = "/(#|" + resources.join("|") + ")/i";
+  return {
+    allOf: [
+      { $ref: typeRef("Reference") },
+      {
+        type: "object",
+        properties: { reference: { type: "string", pattern: pattern } }
+      }
+    ]
+  };
+};
+
+var elementType = function(el) {
+  if (!el.type) {
+    return "object";
+  }
+  var code = utils.getIn(el, ["type", 0, "code"]);
+  if (code === "Reference") {
+    return buildReferenceSchema(el);
+  }
+
+  utils.assert(el.type.length == 1, el.path + JSON.stringify(el.type));
+  utils.assert(code, JSON.stringify(el));
+
+  if (isPrimitive(code)) {
+    return code;
+  }
+  if (code === "BackboneElement") {
+    return "object";
+  }
+  return { $ref: typeRef(code) };
+};
+
+var expandPath = function(spath, tp) {
+  var path = spath.split(".");
+  var last = path[path.length - 1];
+  var newpath = path.slice(0, path.length - 1);
+  newpath.push(last.replace("[x]", utils.capitalize(tp.code)));
+  return newpath.join(".");
+};
+
+var isFhirPrimitive = function(el) {
+  var tp = utils.getIn(el, ["type", 0, "code"]);
+  return tp && tp[0].toLowerCase() == tp[0];
 };
 
 var EXTENSION = {
-    type: 'object',
-    properties: {
-        extension: {
-            type: 'array',
-            items: {
-                oneOf: [{$ref: typeRef('Extension')}, {type: 'null'}]
-            }
-        }
+  type: "object",
+  properties: {
+    extension: {
+      type: "array",
+      items: {
+        oneOf: [{ $ref: typeRef("Extension") }, { type: "null" }]
+      }
     }
+  }
 };
-var EXTENSION_ARRAY= {
-    type: 'array',
-    items: {oneOf: [EXTENSION, {type: 'null'}]}
+var EXTENSION_ARRAY = {
+  type: "array",
+  items: { oneOf: [EXTENSION, { type: "null" }] }
 };
 
-var primitiveExtensions = function(prop, el){
-    if(isFhirPrimitive(el)){
-        var path = utils.copy(prop.$$path);
-        path[path.length - 1] = "_" + utils.last(path);
-        var eprop = utils.merge((prop.type == 'array') ? EXTENSION_ARRAY : EXTENSION, {$$path: path});
-        return [prop, eprop];
+var primitiveExtensions = function(prop, el) {
+  if (isFhirPrimitive(el)) {
+    var path = utils.copy(prop.$$path);
+    path[path.length - 1] = "_" + utils.last(path);
+    var eprop = utils.merge(
+      prop.type == "array" ? EXTENSION_ARRAY : EXTENSION,
+      { $$path: path }
+    );
+    return [prop, eprop];
+  } else {
+    return [prop];
+  }
+};
+
+var onlyTypedElement2schema = function(el) {
+  utils.assert(el.path, JSON.stringify(el));
+  var path = el.path.split(".");
+
+  var res = { $$path: path, title: el.short };
+  if (settings.build) {
+    delete res.title;
+  }
+  if (path.length == 1) {
+    //root element
+    // res.id = path[0]
+    res.type = "object";
+  } else if (el.max === "*") {
+    res.type = "array";
+    res.minItems = minItems(el);
+    res.items = {};
+    var etp = elementType(el);
+    if (etp.$ref) {
+      res.items.$ref = etp.$ref;
+    } else if (etp.allOf) {
+      res.items.allOf = etp.allOf;
     } else {
-        return [prop];
+      res.items.type = etp;
     }
-};
-
-var onlyTypedElement2schema = function(el){
-    utils.assert(el.path, JSON.stringify(el));
-    var path = el.path.split('.');
-
-    var res = {$$path: path, title: el.short};
-    if(settings.build){
-        delete res.title;
+    //HACK: handle null in extension and primitve arrays
+    if (path[path.length - 1] == "extension" || isFhirPrimitive(el)) {
+      res.items = { oneOf: [res.items, { type: "null" }] };
     }
-    if(path.length == 1){
-        //root element
-        // res.id = path[0]
-        res.type = 'object';
-    } else if (el.max === '*'){
-        res.type = 'array' ;
-        res.minItems = minItems(el);
-        res.items = {};
-        var etp = elementType(el);
-        if(etp.$ref){
-            res.items.$ref = etp.$ref ;
-        }else if(etp.allOf){
-            res.items.allOf = etp.allOf;
-        }else{
-            res.items.type = etp;
-        }
-        //HACK: handle null in extension and primitve arrays
-        if(path[path.length - 1] == 'extension' || isFhirPrimitive(el)){
-            res.items = {oneOf: [res.items, {type: 'null'}]} ;
-        }
+  } else {
+    // res.$$required = isRequired(el);
+    var etp = elementType(el);
+    if (etp.$ref) {
+      res.$ref = etp.$ref;
+    } else if (etp.allOf) {
+      res.allOf = etp.allOf;
     } else {
-        // res.$$required = isRequired(el);
-        var etp = elementType(el);
-        if(etp.$ref){
-            res.$ref = etp.$ref;
-        }else if(etp.allOf){
-            res.allOf = etp.allOf;
-        }else{
-           res.type = etp;
-        }
+      res.type = etp;
     }
-    if(res.type == 'object'){
-        res.additionalProperties = false;
-        res.properties = res.properties || {};
-        res.properties.fhir_comments = {type: 'array', items: {type: 'string'}};
-    }
-    return primitiveExtensions(res, el);
+  }
+  if (res.type == "object") {
+    res.additionalProperties = false;
+    res.properties = res.properties || {};
+    res.properties.fhir_comments = { type: "array", items: { type: "string" } };
+  }
+  return primitiveExtensions(res, el);
 };
 
-function element2schema(el){
-    utils.assert(el.path, JSON.stringify(el));
-    if(isPolymorphic(el)){
-        var groupedTypes = el.type.reduce(function(acc, tp){
-            acc[tp.code] = acc[tp.code] || [];
-            acc[tp.code].push(tp);
-            return acc;
-        }, {});
+function element2schema(el) {
+  utils.assert(el.path, JSON.stringify(el));
+  if (isPolymorphic(el)) {
+    var groupedTypes = el.type.reduce(function(acc, tp) {
+      acc[tp.code] = acc[tp.code] || [];
+      acc[tp.code].push(tp);
+      return acc;
+    }, {});
 
-        var result = [];
-        for(var code in groupedTypes){
-            var types = groupedTypes[code];
-            var newpath = expandPath(el.path, {code: code});
-            result.push.apply(result, onlyTypedElement2schema(
-                utils.merge(el, {type: types, path: newpath})
-            ));
-        }
-        return result;
+    var result = [];
+    for (var code in groupedTypes) {
+      var types = groupedTypes[code];
+      var newpath = expandPath(el.path, { code: code });
+      result.push.apply(
+        result,
+        onlyTypedElement2schema(utils.merge(el, { type: types, path: newpath }))
+      );
     }
-    return onlyTypedElement2schema(el);
+    return result;
+  }
+  return onlyTypedElement2schema(el);
+}
+
+var addToSchema = function(sch, elem) {
+  var path = elem.$$path;
+  delete elem.$$path;
+  var cur = sch;
+  sch.properties = sch.properties || {};
+  for (var i = 0; i < path.length - 1; i++) {
+    var item = path[i];
+    cur.properties = cur.properties || {};
+    cur = cur.properties[item];
+    utils.assert(cur, item + JSON.stringify(path));
+    if (cur.type && cur.type == "array") {
+      cur = cur.items;
+    }
+  }
+  item = path[path.length - 1];
+  if (cur.type == "array") {
+    cur.item.properties = cur.item.properties || {};
+    cur.item.properties[item] = elem;
+  } else {
+    cur.properties = cur.properties || {};
+    cur.properties[item] = elem;
+  }
+  return sch;
 };
-
-
-var addToSchema = function (sch, elem){
-    var path = elem.$$path;
-    delete elem.$$path;
-    var cur = sch;
-    sch.properties = sch.properties || {};
-    for(var i = 0; i < path.length - 1; i++){
-        var item = path[i];
-        cur.properties = cur.properties || {};
-        cur = cur.properties[item];
-        utils.assert(cur, item + JSON.stringify(path));
-        if(cur.type && cur.type == 'array'){
-            cur = cur.items;
-        }
-    }
-    item = path[path.length - 1];
-    if(cur.type == 'array'){
-        cur.item.properties = cur.item.properties || {};
-        cur.item.properties[item] = elem;
-    } else {
-        cur.properties = cur.properties || {};
-        cur.properties[item] = elem;
-    }
-    return sch;
-};
-var addStructureDefinition = function(schema, structureDefinition){
-    var rt = structureDefinition.name;
-    if(rt == 'id') {return schema;}
-    if(OVERRIDEN[rt]) {return schema;}
-    if(isPrimitive(rt)) {return schema;}
-    var sd =  structureDefinition
-        .snapshot
-        .element
-        .reduce(function(acc, el){
-            // FIX: path for inherited data types
-            var path = [rt].concat(el.path.split('.').slice(1)).join('.');
-            el.path = path;
-            var res = element2schema(el);
-            if(!res) throw new Error('UPS:' + el);
-            return res.reduce(function(acc, el){
-                return addToSchema(acc, el);
-            }, acc);
-        }, {});
-
-    schema.definitions = schema.definitions || {};
-    var resourceSchema = sd.properties[rt];
-    if(resourceSchema && resourceSchema.properties) {
-        resourceSchema.properties.resourceType = {type: 'string'};
-    }
-    schema.definitions[rt] = resourceSchema;
+var addStructureDefinition = function(schema, structureDefinition) {
+  var rt = structureDefinition.name;
+  if (rt == "id") {
     return schema;
-};
-
-var addValueSet = function(schema, valueSet){
-};
-
-var add = function(schema, resource){
-    var rt = resource.resourceType;
-    if(rt == 'StructureDefinition'){
-        return  addStructureDefinition(schema, resource);
-    } else if (rt == 'ValueSet'){
-        return addValueSet(schema, resource);
-    } else if (rt == 'Bundle'){
-        resource.entry.reduce(function(acc, entry){
-            return add(acc, entry.resource);
-        }, schema);
-    }else {
-        return schema;
-    }
-};
-
-var BASE_PROFILES = ['Resource', 'DomainResource', 'Element', 'BackboneElement'];
-
-var fixSchema = function(schema){
-    BASE_PROFILES.forEach(function(x){
-        if(schema.definitions[x]){
-            schema.definitions[x].additionalProperties = true;
-        }
-    });
-    for(var k in OVERRIDEN) {
-        var v = OVERRIDEN[k];
-        schema.definitions[k] = v;
-    }
+  }
+  if (OVERRIDEN[rt]) {
     return schema;
-};
-
-function makeSchema(cb, opts){
-    var schema = { type: 'object' };
-    var oldSettings = settings; 
-
-    if(opts){ settings = utils.merge(settings, opts); }
-
-    schema.add = function(res){ add(schema, res); };
-
-    schema = cb(schema);
-    fixSchema(schema);
-
-    settings = oldSettings;
+  }
+  if (isPrimitive(rt)) {
     return schema;
+  }
+  var sd = structureDefinition.snapshot.element.reduce(function(acc, el) {
+    // FIX: path for inherited data types
+    var path = [rt].concat(el.path.split(".").slice(1)).join(".");
+    el.path = path;
+    var res = element2schema(el);
+    if (!res) throw new Error("UPS:" + el);
+    return res.reduce(function(acc, el) {
+      return addToSchema(acc, el);
+    }, acc);
+  }, {});
+
+  schema.definitions = schema.definitions || {};
+  var resourceSchema = sd.properties[rt];
+  if (resourceSchema && resourceSchema.properties) {
+    resourceSchema.properties.resourceType = { type: "string" };
+  }
+  schema.definitions[rt] = resourceSchema;
+  return schema;
 };
+
+var addValueSet = function(schema, valueSet) {};
+
+var add = function(schema, resource) {
+  var rt = resource.resourceType;
+  if (rt == "StructureDefinition") {
+    return addStructureDefinition(schema, resource);
+  } else if (rt == "ValueSet") {
+    return addValueSet(schema, resource);
+  } else if (rt == "Bundle") {
+    resource.entry.reduce(function(acc, entry) {
+      return add(acc, entry.resource);
+    }, schema);
+  } else {
+    return schema;
+  }
+};
+
+var BASE_PROFILES = [
+  "Resource",
+  "DomainResource",
+  "Element",
+  "BackboneElement"
+];
+
+var fixSchema = function(schema) {
+  BASE_PROFILES.forEach(function(x) {
+    if (schema.definitions[x]) {
+      schema.definitions[x].additionalProperties = true;
+    }
+  });
+  for (var k in OVERRIDEN) {
+    var v = OVERRIDEN[k];
+    schema.definitions[k] = v;
+  }
+  return schema;
+};
+
+function makeSchema(cb, opts) {
+  var schema = { type: "object" };
+  var oldSettings = settings;
+
+  if (opts) {
+    settings = utils.merge(settings, opts);
+  }
+
+  schema.add = function(res) {
+    add(schema, res);
+  };
+
+  schema = cb(schema);
+  fixSchema(schema);
+
+  settings = oldSettings;
+  return schema;
+}


### PR DESCRIPTION
The main changes in this pr is to use `http://build.fhir.org` and add a check for code or _code in the assert of the build step.

``` js
var code = utils.getIn(el, ["type", 0, "code"]);
  var _code = utils.getIn(el, ["type", 0, "_code"]);
  if (code === "Reference") {
    return buildReferenceSchema(el);
  }

  utils.assert(el.type.length == 1, el.path + JSON.stringify(el.type));

  utils.assert(code || _code, JSON.stringify(el));

```

Sorry for all the file changes, I prettier installed and it made a lot of modifications.